### PR TITLE
Remove pip flag when video finishes

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -8,10 +8,10 @@ if (!document.pictureInPictureEnabled) {
         
         if (video.hasAttribute('__pip__')) {
           await document.exitPictureInPicture();
-          video.removeAttribute('__pip__');
         } else {
           await video.requestPictureInPicture();
           video.setAttribute('__pip__', true);
+          video.addEventListener('leavepictureinpicture', () => video.removeAttribute('__pip__'));
         }
       })();
     `;


### PR DESCRIPTION
This fixes the following bug:
1. Open a video on Youtube
2. Click on this chrome extension to put the video in the picture-in-picture mode
3. Wait until the video finishes and the picture-in-picture window automatically closes
4. Click on another video (or alternatively - wait until the next video starts playing because of Youtube's autoplay, or navigate "back" to another video)
5. Click on this chrome extension
Expected:
6. Video is in picture-in-picture mode
Actual:
6. Nothing happens, a console error is logged

This happens because the `<video>` element is not replaced when you navigate to another Youtube video, simlpy the `src` is changed, but the node is the same. In this case the `<video>` element still has the `__pip__="true"` attribute which is incorrectly reporting that the video is in picture-in-picture mode when it isn't.